### PR TITLE
Update repository URLs to use emacs-php ones

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,6 +1,6 @@
 #+TITLE: ede-php-autoload
 
-[[http://melpa.org/#/ede-php-autoload][file:http://melpa.org/packages/ede-php-autoload-badge.svg]] [[http://stable.melpa.org/#/ede-php-autoload][file:http://stable.melpa.org/packages/ede-php-autoload-badge.svg]] [[https://travis-ci.org/stevenremot/ede-php-autoload][file:https://travis-ci.org/stevenremot/ede-php-autoload.svg]]
+[[http://melpa.org/#/ede-php-autoload][file:http://melpa.org/packages/ede-php-autoload-badge.svg]] [[http://stable.melpa.org/#/ede-php-autoload][file:http://stable.melpa.org/packages/ede-php-autoload-badge.svg]] [[https://travis-ci.org/emacs-php/ede-php-autoload][file:https://travis-ci.org/emacs-php/ede-php-autoload.svg]]
 
 * Description
 

--- a/ede-php-autoload-composer.el
+++ b/ede-php-autoload-composer.el
@@ -4,7 +4,7 @@
 
 ;; Author: Steven Rémot <steven.remot@gmail.com>
 ;; Keywords: PHP project ede
-;; Homepage: https://github.com/stevenremot/ede-php-autoload
+;; Homepage: https://github.com/emacs-php/ede-php-autoload
 
 ;; This file is not part of GNU Emacs.
 

--- a/ede-php-autoload-mode.el
+++ b/ede-php-autoload-mode.el
@@ -5,7 +5,7 @@
 ;; Author: Steven Rémot <steven.remot@gmail.com>
 ;;         original code for C++ by Eric M. Ludlam <eric@siege-engine.com>
 ;; Keywords: PHP project ede
-;; Homepage: https://github.com/stevenremot/ede-php-autoload
+;; Homepage: https://github.com/emacs-php/ede-php-autoload
 
 ;; This file is not part of GNU Emacs.
 

--- a/ede-php-autoload-semanticdb.el
+++ b/ede-php-autoload-semanticdb.el
@@ -5,7 +5,7 @@
 ;; Author: Steven Rémot <steven.remot@gmail.com>
 ;;         Inspired by Joris Stein's edep <https://github.com/jorissteyn/edep>
 ;; Keywords: PHP project ede
-;; Homepage: https://github.com/stevenremot/ede-php-autoload
+;; Homepage: https://github.com/emacs-php/ede-php-autoload
 
 ;; This file is not part of GNU Emacs.
 

--- a/ede-php-autoload.el
+++ b/ede-php-autoload.el
@@ -5,7 +5,7 @@
 ;; Author: Steven Rémot <steven.remot@gmail.com>
 ;;         original code for C++ by Eric M. Ludlam <eric@siege-engine.com>
 ;; Keywords: PHP project ede
-;; Homepage: https://github.com/stevenremot/ede-php-autoload
+;; Homepage: https://github.com/emacs-php/ede-php-autoload
 
 ;; This file is not part of GNU Emacs.
 

--- a/test/ede-php-autoload-composer-test.el
+++ b/test/ede-php-autoload-composer-test.el
@@ -6,7 +6,7 @@
 
 ;; Author: Steven Rémot <steven.remot@gmail.com>
 ;; Keywords: PHP project ede
-;; Homepage: https://github.com/stevenremot/ede-php-autoload
+;; Homepage: https://github.com/emacs-php/ede-php-autoload
 
 ;; This file is not part of GNU Emacs.
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -6,7 +6,7 @@
 
 ;; Author: Steven Rémot <steven.remot@gmail.com>
 ;; Keywords: PHP project ede
-;; Homepage: https://github.com/stevenremot/ede-php-autoload
+;; Homepage: https://github.com/emacs-php/ede-php-autoload
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Now that the repository has moved to emacs-php, update the URLs to
reflect it.

Part of #29 