### PR TITLE
Use evm to setup emacs on the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,17 @@
 # Config file copied from https://github.com/flycheck/emacs-travis
 language: emacs-lisp
-# Emacs fails to build in container-based builds on Travis
-# See https://github.com/travis-ci/travis-ci/issues/9061
-# and https://github.com/moby/moby/issues/22801
-sudo: required
-dist: trusty
-cache:
-  - directories:
-      # Cache stable Emacs binaries (saves 1min per job)
-      - "$HOME/emacs/"
-# Allow Emacs snapshot builds to fail and don’t wait for these as they can take
-# a looooong time
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EMACS_VERSION=snapshot
 env:
-  - EMACS_VERSION=24.3
-  - EMACS_VERSION=24.5
-  - EMACS_VERSION=25.1
-  - EMACS_VERSION=26.1
-  - EMACS_VERSION=snapshot
+  - EMACS_VERSION=emacs-24.3-travis
+  - EMACS_VERSION=emacs-24.5-travis
+  - EMACS_VERSION=emacs-25.3-travis
+  - EMACS_VERSION=emacs-26.1-travis
+  - EMACS_VERSION=emacs-git-snapshot-travis
 before_install:
-  # Configure $PATH: Executables are installed to $HOME/bin
-  - export PATH="$HOME/bin:$PATH"
-  # Download the makefile to emacs-travis.mk
-  - wget 'https://raw.githubusercontent.com/flycheck/emacs-travis/master/emacs-travis.mk'
-  # Install Emacs (according to $EMACS_VERSION) and Cask
-  - make -f emacs-travis.mk install_emacs
-  - make -f emacs-travis.mk install_cask
+  - export PATH="/home/travis/.evm/bin:/home/travis/.cask/bin:$PATH"
+  - git clone https://github.com/rejeep/evm.git /home/travis/.evm
+  - evm config path /tmp
+  - evm install $EMACS_VERSION --use || true
+  - curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 install:
   # Install your dependencies
   - cask install


### PR DESCRIPTION
emacs-travis seems to have issues with emacs 26. Use evm instead.